### PR TITLE
Fix for BC break in goaop/framework

### DIFF
--- a/src/AspectMock/Intercept/BeforeMockTransformer.php
+++ b/src/AspectMock/Intercept/BeforeMockTransformer.php
@@ -6,6 +6,7 @@ namespace AspectMock\Intercept;
 
 use Go\Aop\Aspect;
 use Go\Instrument\Transformer\StreamMetaData;
+use Go\Instrument\Transformer\TransformerResultEnum;
 use Go\Instrument\Transformer\WeavingTransformer;
 use Go\ParserReflection\ReflectionFile;
 use Go\ParserReflection\ReflectionMethod;
@@ -15,9 +16,9 @@ class BeforeMockTransformer extends WeavingTransformer
     protected string $before = " if ((\$__am_res = __amock_before(\$this, __CLASS__, __FUNCTION__, array(%s), false)) !== __AM_CONTINUE__) return \$__am_res; ";
     protected string $beforeStatic = " if ((\$__am_res = __amock_before(get_called_class(), __CLASS__, __FUNCTION__, array(%s), true)) !== __AM_CONTINUE__) return \$__am_res; ";
 
-    public function transform(StreamMetaData $metadata): string
+    public function transform(StreamMetaData $metadata): TransformerResultEnum
     {
-        $result        = self::RESULT_ABSTAIN;
+        $result        = TransformerResultEnum::RESULT_ABSTAIN;
         $reflectedFile = new ReflectionFile($metadata->uri, $metadata->syntaxTree);
         $namespaces    = $reflectedFile->getFileNamespaces();
 
@@ -75,7 +76,7 @@ class BeforeMockTransformer extends WeavingTransformer
                     do {
                         if (($metadata->tokenStream[$tokenPosition]->text ?? '') === '{') {
                             $metadata->tokenStream[$tokenPosition]->text .= $beforeDefinition;
-                            $result = self::RESULT_TRANSFORMED;
+                            $result = TransformerResultEnum::RESULT_TRANSFORMED;
                             break;
                         }
                         $tokenPosition++;


### PR DESCRIPTION
 Cherry-pick of upstream Codeception/AspectMock@1a0735d264 (PR #214 by JJCLane,
  merged 2025-08-12) to restore compatibility with goaop/framework dev-master.

  Without this fix, AspectMock fails at class load:
    Declaration of BeforeMockTransformer::transform(): string must be compatible
    with WeavingTransformer::transform(): TransformerResultEnum

  Verified on splynx-payfast — 80 tests (31 unit + 49 functional) all green.
  
  Jira: SABASE2-14